### PR TITLE
add support for arbitrary-precision results with mpmath

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,6 +30,7 @@ jobs:
         # pip install .
         pip install numpy>=1.22
         pip install scipy>=1.8.1
+        pip install mpmath>=1.0
     - name: Test with unittest
       run: |
         python -m unittest

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ To compute the full matrices, an optimized algorithm making use of recursive pat
 
 Furthermore, the function `single_shot_estimators(n)` generates single-shot estimators for $a$, $b$, $a'$, $b'$, $a''$, and $b''$ for all possible numbers $m=0,...,n$ of singlets as an outcome of a two-copy Bell measurement. This function returns six 2D-arrays (one for each quantum weight enumerator in the order as given above) with the estimator for $m$ singlets in the $m$-th column. 
 
+### High-precision transformation matrices
+
+For some applications, a higher precision than 64 bit floating point is needed for the transformation matrices. For this purpose, each transformation features a `precise` argument (which defaults to `false`). If set to `true`, an `mpmath.matrix` is returned instead of an `np.array`. This requires [`mpmath`](https://mpmath.org/) to be installed. The precision can for example be set via `mpmath.mp.dps = 120` (more on precision with mpmath, see [here](https://mpmath.org/doc/current/basics.html#setting-the-precision)) before calling the transformation generator. 
 
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,12 @@ dependencies = [
     "scipy >= 1.8.1"
 ]
 
+[project.optional-dependencies]
+Precision = [
+  "mpmath >= 1.0"
+]
+
+
 [project.urls]
 "Homepage" = "https://github.com/Mc-Zen/qsalto"
 "Bug Tracker" = "https://github.com/Mc-Zen/qsalto/issues"

--- a/src/qsalto/__init__.py
+++ b/src/qsalto/__init__.py
@@ -1,3 +1,13 @@
+""" 
+qsalto
+======
+
+Provides transformations between several (normalized) quantum weight enumerators, including
+- Shor-Laflamme enumerators a, b,
+- Rains unitary enumerators a', b',
+- and Rains shadow enumerators a''.
+
+"""
 
 from .matrices import M, M1, M2, T1, iT1, T2, iT2, T3, iT3
 from .single_shot import single_shot_estimators

--- a/src/qsalto/matrices.py
+++ b/src/qsalto/matrices.py
@@ -7,8 +7,12 @@ from . import single_entry
 try:
     import mpmath as mp
 except ImportError:
-    pass
-    # external_module = None 
+    class mp_not_available:
+        def __getattr__(self, _):
+            raise RuntimeError(
+                "In order to use the `precise` mode, you need to install the python package mpmath"
+            )
+    mp = mp_not_available()
 
 
 def comb(n, k):
@@ -25,6 +29,7 @@ def assert_valid_entry(entry, n):
 # def M(n: int, precise=False) -> np.ndarray: ...
 # @overload
 # def M(n: int, entry: tuple, precise=False) -> float: ...
+
 
 def M(n: int, entry: Union[tuple, None] = None, precise=False) -> Union[np.ndarray, float]:
     """Self-inverse transformation matrix between Shor-Laflamme distributions $a$ and $b$.
@@ -210,7 +215,7 @@ def iT1(n: int, entry: Union[tuple, None] = None, precise=False) -> Union[np.nda
         K = mp.matrix(K)
     else:
         K = np.array(K, dtype=float)
-    
+
     for l in reversed(range(n + 1)):
         K[:, l] *= K[l, 0] / 2**(n - l)
     for l in range(n + 1):
@@ -243,7 +248,7 @@ def T3(n: int, entry: Union[tuple, None] = None, precise=False) -> Union[np.ndar
     for k in range(1, n + 1):
         for l in range(1, n + 1):
             K[k][l] = K[k - 1][l - 1] - K[k - 1][l] - K[k][l - 1]
-    
+
     if precise:
         K = mp.matrix(K)
     else:
@@ -278,7 +283,7 @@ def iT3(n: int, entry: Union[tuple, None] = None, precise=False) -> Union[np.nda
     for k in range(1, n + 1):
         for l in range(1, n + 1):
             K[k][l] = K[k - 1][l - 1] + K[k - 1][l] + K[k][l - 1]
-    
+
     if precise:
         K = mp.matrix(K)
     else:

--- a/src/qsalto/mp_not_available.py
+++ b/src/qsalto/mp_not_available.py
@@ -1,0 +1,5 @@
+class mp_error:
+    def __getattr__(self, _):
+        raise RuntimeError(
+            "In order to use the `precise` mode, you need to install the python package mpmath"
+        )

--- a/src/qsalto/single_entry.py
+++ b/src/qsalto/single_entry.py
@@ -8,7 +8,7 @@ def comb(n, k):
 
 def M(n: int, i: int, j: int) -> float:
     sum = 0
-    for l in range(n + 1):
+    for l in range(i + 1):
         sum += comb(n - j, i - l) * comb(j, l) * (-1)**l * 3**(i - l)
     return sum / 2**n
 
@@ -51,13 +51,13 @@ def iT1(n: int, i: int, j: int) -> float:
 
 def T3(n: int, i: int, j: int) -> float:
     sum = 0
-    for l in range(n + 1):
+    for l in range(i + 1):
         sum += comb(n - j, i - l) * comb(j, l) * (-1)**(j - l)
     return sum * comb(n, j) / 2**n
 
 
 def iT3(n: int, i: int, j: int) -> float:
-    sum = 0.
-    for l in range(n + 1):
+    sum = 0
+    for l in range(i + 1):
         sum += comb(n - j, i - l) * comb(j, l) * (-1)**(i - l)
     return sum / comb(n, i)

--- a/src/qsalto/single_entry_precise.py
+++ b/src/qsalto/single_entry_precise.py
@@ -1,0 +1,70 @@
+
+from scipy.special import comb as scomb
+
+
+try:
+    import mpmath as mp
+except ImportError:
+    import mp_not_available
+    mp = mp_not_available.mp_error()
+
+
+def comb(n, k):
+    return scomb(n, k, exact=True)
+
+
+def M(n: int, i: int, j: int):
+    sum = 0
+    for l in range(i + 1):
+        sum += comb(n - j, i - l) * comb(j, l) * (-1)**l * 3**(i - l)
+    return mp.mpf(sum) / 2**n
+
+
+def M1(n: int, i: int, j: int):
+    if i == n - j:
+        return mp.mpf(1)
+    return mp.mpf(0)
+
+
+def M2(n: int, i: int, j: int):
+    if i != j:
+        return 0.
+    if (n - i) % 2 == 0:
+        return mp.mpf(1)
+    return mp.mpf(-1)
+
+
+def T2(n: int, i: int, j: int):
+    value = M(n, i, j)
+    if j % 2 == 1:
+        value *= -1
+    return value
+
+
+def iT2(n: int, i: int, j: int):
+    value = M(n, i, j)
+    if i % 2 == 1:
+        value *= -1
+    return value
+
+
+def T1(n: int, i: int, j: int):
+    return mp.mpf(comb(n - j, n - i)) * mp.power(2, n - i) / comb(n, i)
+
+
+def iT1(n: int, i: int, j: int):
+    return mp.mpf(comb(n - j, i - j) * (-1)**(i + j) * comb(n, j)) / 2**(n - j)
+
+
+def T3(n: int, i: int, j: int):
+    sum = 0
+    for l in range(i + 1):
+        sum += comb(n - j, i - l) * comb(j, l) * int((-1)**(j - l))
+    return mp.mpf(sum * comb(n, j)) / 2**n
+
+
+def iT3(n: int, i: int, j: int):
+    sum = 0
+    for l in range(i + 1):
+        sum += comb(n - j, i - l) * comb(j, l) * (-1)**(i - l)
+    return mp.mpf(sum) / comb(n, i)

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -59,8 +59,34 @@ class TestData(unittest.TestCase):
         for t in [M, M1, M2, T1, iT1, T2, iT2, T3, iT3]:
             with self.subTest("", t=t):
                 n = 11
-                matrix = t(n)
+                matrix = t(np.int64(n))
                 for i in range(n + 1):
                     for j in range(n + 1):
-                        val = t(n, entry=[i, j])
+                        val = t(np.int64(n), entry=[i, j])
                         np.testing.assert_allclose(matrix[i, j], val)
+
+    def test_1000_qubits(self):
+        for t in [M, M1, M2, T1, iT1, T2, iT2, T3, iT3]:
+            with self.subTest("", t=t):
+                t(1000)
+
+    def test_numpy_int_for_n(self):
+        for t in [M, M1, M2, T1, iT1, T2, iT2, T3, iT3]:
+            with self.subTest("", t=t):
+                n = np.int64(11)
+                matrix = t(n)
+                val = t(n, entry=[0, 0])
+
+    def test_precise_mode(self):
+        for t in [M, M1, M2, T1, iT1, T2, iT2, T3, iT3]:
+            for n in [2, 11, 37, 39, 55, 63]:
+                with self.subTest("", t=t, n=n):
+                    K1 = t(n, precise=False)
+                    K2 = t(n, precise=True)
+                    np.testing.assert_allclose(K1, np.array(K2.tolist(), dtype=float))
+
+
+    def test_f(self):
+        a: np.ndarray = M(3)
+        b: float = M(3, entry=(2,3))
+        c: np.ndarray = M(3, precise=True)

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -59,11 +59,22 @@ class TestData(unittest.TestCase):
         for t in [M, M1, M2, T1, iT1, T2, iT2, T3, iT3]:
             with self.subTest("", t=t):
                 n = 11
-                matrix = t(np.int64(n))
+                matrix = t(n)
                 for i in range(n + 1):
                     for j in range(n + 1):
-                        val = t(np.int64(n), entry=[i, j])
+                        val = t(n, entry=(i, j))
                         np.testing.assert_allclose(matrix[i, j], val)
+
+    def test_single_entry_precise(self):
+        import mpmath as mp
+        for t in [M, M1, M2, T1, iT1, T2, iT2, T3, iT3]:
+            with self.subTest("", t=t):
+                n = 20
+                matrix = t(n, precise=True)
+                for i in range(n + 1):
+                    for j in range(n + 1):
+                        val = t(n, entry=(i, j), precise=True)
+                        assert mp.fabs(matrix[i, j] - val) < 1e-10
 
     def test_1000_qubits(self):
         for t in [M, M1, M2, T1, iT1, T2, iT2, T3, iT3]:
@@ -75,7 +86,7 @@ class TestData(unittest.TestCase):
             with self.subTest("", t=t):
                 n = np.int64(11)
                 matrix = t(n)
-                val = t(n, entry=[0, 0])
+                val = t(n, entry=(0, 0))
 
     def test_precise_mode(self):
         for t in [M, M1, M2, T1, iT1, T2, iT2, T3, iT3]:
@@ -85,8 +96,7 @@ class TestData(unittest.TestCase):
                     K2 = t(n, precise=True)
                     np.testing.assert_allclose(K1, np.array(K2.tolist(), dtype=float))
 
-
     def test_f(self):
         a: np.ndarray = M(3)
-        b: float = M(3, entry=(2,3))
-        c: np.ndarray = M(3, precise=True)
+        b: float = M(3, entry=(2, 3))
+        c: np.ndarray = M(3, precise=True,)


### PR DESCRIPTION
This PR adds a `precise: boolean` parameter to all matrices. If called with `precise=True`, an [`mpmath.matrix`](https://mpmath.org/doc/current/matrices.html) with the current [mpmath precision](https://mpmath.org/doc/current/basics.html#setting-the-precision) is returned. An error is raised dynamically if mpmath cannot be loaded. 

If this feature is not used, mpmath does not have to be installed. 