### PR TITLE
Fix import error of mp_not_available

### DIFF
--- a/src/qsalto/matrices.py
+++ b/src/qsalto/matrices.py
@@ -8,8 +8,8 @@ from . import single_entry_precise
 try:
     import mpmath as mp
 except ImportError:
-    import mp_not_available
-    mp = mp_not_available.mp_error()
+    from .mp_not_available import mp_error
+    mp = mp_error()
 
 def get_single_entry(precise):
     return single_entry_precise if precise else single_entry

--- a/src/qsalto/single_entry_precise.py
+++ b/src/qsalto/single_entry_precise.py
@@ -5,8 +5,8 @@ from math import comb as scomb
 try:
     import mpmath as mp
 except ImportError:
-    import mp_not_available
-    mp = mp_not_available.mp_error()
+    from .mp_not_available import mp_error
+    mp = mp_error()
 
 
 def comb(n, k):


### PR DESCRIPTION
Fixes the import of `mp_not_available` to prevent errors when `mpmath` is not installed.